### PR TITLE
Add prisma folder path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "ts-jest": "^29.3.1",
     "typescript": "^5"
   },
+  "prisma": {
+    "schema": "./prisma"
+  },
   "packageManager": "pnpm@10.4.0+sha512.6b849d0787d97f8f4e1f03a9b8ff8f038e79e153d6f11ae539ae7c435ff9e796df6a862c991502695c7f9e8fac8aeafc1ac5a8dab47e36148d183832d886dd52"
 }


### PR DESCRIPTION
"As of v6.6.0, you must always explicitly specify the location of your Prisma schema folder. There is no "magic" detection of the Prisma schema folder in a default location any more."  https://www.prisma.io/docs/orm/prisma-schema/overview/location#usage